### PR TITLE
Parse string to float64 when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,6 @@ GraphQL metrics exporter for Prometheus.
 
 This piece of software has one mission: query GraphQL endpoints and transform their results into Prometheus metrics.
 
-# Additions
-Edited `query.go` so it attempts to convert a string to a float64. When graphql returns data it can often be in a string format
-```
-case string:
-  // try to convert string to int
-  data_float, err := strconv.ParseFloat((*data).(string), 32)
-  if err == nil {
-   setGaugeValue(r, labels, path, data_float)
-  } else {
-   labels["value"] = (*data).(string)
-   setGaugeValue(r, labels, path, 1)
-   delete(labels, "value")
-  }
-```
-
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@ GraphQL metrics exporter for Prometheus.
 
 This piece of software has one mission: query GraphQL endpoints and transform their results into Prometheus metrics.
 
+# Additions
+Edited `query.go` so it attempts to convert a string to a float64. When graphql returns data it can often be in a string format
+```
+case string:
+  // try to convert string to int
+  data_float, err := strconv.ParseFloat((*data).(string), 32)
+  if err == nil {
+   setGaugeValue(r, labels, path, data_float)
+  } else {
+   labels["value"] = (*data).(string)
+   setGaugeValue(r, labels, path, 1)
+   delete(labels, "value")
+  }
+```
+
 
 # Usage
 

--- a/query.go
+++ b/query.go
@@ -160,25 +160,22 @@ func responseDataAsMetrics(r *prometheus.Registry, labels prometheus.Labels, pat
 	case float64:
 		setGaugeValue(r, labels, path, (*data).(float64))
 
-	// String values are not supported by Prometheus, so the usual workaround is
-	// followed: the value is stored as the value of a metric called "value", and
-	// the metric with that label takes the value of 1.
+	// String values are not supported by Prometheus, so:
+	//   - the string value is stored as the value of a "value" label; and
+	//   - if the string value is representable as a 64-bit floating point number,
+	//     it is converted and stored as the gauge value of the metric;
+	//   - if not, the gauge value is set to 1.
 	// Beware, however, that if a value changed since its last scrape, it will not
 	// be returned as 0, since we don't know about its existence now.
-
-	// there are some instances where graphql returns a float that is represented as a string
-	// try to convert to float here so it can be properly represented as time series data
- case string:
-  // try to convert string to int
-  data_float, err := strconv.ParseFloat((*data).(string), 32)
-  if err == nil {
-   setGaugeValue(r, labels, path, data_float)
-  } else {
-   labels["value"] = (*data).(string)
-   setGaugeValue(r, labels, path, 1)
-   delete(labels, "value")
-  }
-
+	case string:
+		labels["value"] = (*data).(string)
+		if value, err := strconv.ParseFloat((*data).(string), 64); err == nil {
+			setGaugeValue(r, labels, path, value)
+		} else {
+			setGaugeValue(r, labels, path, 1)
+		}
+		delete(labels, "value")
+		
 	// Arrays are recursively inspected.
 	// To uniquely identify items within arrays, a label is added to all metrics
 	// contained in the array. Its name is the last value in path, and its value

--- a/query.go
+++ b/query.go
@@ -165,10 +165,19 @@ func responseDataAsMetrics(r *prometheus.Registry, labels prometheus.Labels, pat
 	// the metric with that label takes the value of 1.
 	// Beware, however, that if a value changed since its last scrape, it will not
 	// be returned as 0, since we don't know about its existence now.
-	case string:
-		labels["value"] = (*data).(string)
-		setGaugeValue(r, labels, path, 1)
-		delete(labels, "value")
+
+	// there are some instances where graphql returns a float that is represented as a string
+	// try to convert to float here so it can be properly represented as time series data
+ case string:
+  // try to convert string to int
+  data_float, err := strconv.ParseFloat((*data).(string), 32)
+  if err == nil {
+   setGaugeValue(r, labels, path, data_float)
+  } else {
+   labels["value"] = (*data).(string)
+   setGaugeValue(r, labels, path, 1)
+   delete(labels, "value")
+  }
 
 	// Arrays are recursively inspected.
 	// To uniquely identify items within arrays, a label is added to all metrics

--- a/query.go
+++ b/query.go
@@ -175,7 +175,7 @@ func responseDataAsMetrics(r *prometheus.Registry, labels prometheus.Labels, pat
 			setGaugeValue(r, labels, path, 1)
 		}
 		delete(labels, "value")
-		
+
 	// Arrays are recursively inspected.
 	// To uniquely identify items within arrays, a label is added to all metrics
 	// contained in the array. Its name is the last value in path, and its value


### PR DESCRIPTION
When querying some graphql endpoints, data that can be represented as `float64` is returned as a string making it unable to be referenced easily via time series. Thus the value is returned as referenced here 

> String values are not supported by Prometheus, so the usual workaround is
	followed: the value is stored as the value of a metric called "value", and
	the metric with that label takes the value of 1.

Adding an if statement to see if the string can be parsed and returned as a `float64` ie not as a label but as the value is a workaround